### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,9 @@ class ApplicationController < ActionController::Base
         devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :first_name, :second_name, :first_name_kana, :second_name_kana, :birthday])
       end
           
+      def new
+        @user = User.new
+      end
       
   
   def basic_auth

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,6 +11,7 @@ end
   
   def new
     @item = Item.new
+
   end
 
   def create
@@ -21,7 +22,7 @@ end
       render :new
     end
   end
-  
+
   def show
     @item = Item.find(params[:id])
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,10 @@ end
     end
   end
   
+  def show
+    @item = Item.find(params[:id])
+  end
+  
 
   private
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
     <% if @items.present? %>
       <% @items.each do |item| %>
         <li class='list'>
-         <%= link_to "#" do %>
+         <%= link_to item_path(item) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
              <%# <% if item.purchase.present?  %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -150,7 +150,8 @@
                 <span class='star-count'>0</span>
               </div>
             </div>
-          </div>
+          </div> 
+          <% end %>
         </li>
       <% end %>
     <% else %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -101,9 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,9 +24,9 @@
     </div>
 <% if user_signed_in?  %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
-    <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", '#', method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", item_path, method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", '#', method: :delete, class:"item-destroy" %>
    <% else %>
    <%# <% if item.stock > 0 %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
@@ -36,7 +36,7 @@
 
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -102,7 +102,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,7 +10,7 @@
       <%= image_tag @item.image ,class:"item-box-img" %>
              <%# <% if item.purchase.present?  %>
       <div class="sold-out">
-        <span>Sold Out!!</span>
+        <%# <span>Sold Out!!</span> %>
       </div>
              <%# <% end %> 
     </div>
@@ -19,7 +19,7 @@
         <% @item.price%>
       </span>
       <span class="item-postage">
-        <%= @item.seller.name %>
+        <%= @item.price %>
       </span>
     </div>
 <% if user_signed_in?  %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,37 +4,36 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+             <%# <% if item.purchase.present?  %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+             <%# <% end %> 
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <% @item.price%>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.seller.name %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+<% if user_signed_in?  %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+    <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <%= link_to "削除", item_path, method: :delete, class:"item-destroy" %>
+   <% else %>
+   <%# <% if item.stock > 0 %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <%# //<% end %>
+<% end %>
+<% end %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +42,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.seller.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,7 +1,7 @@
-<% if @item.errors.any? %>
+<% if model.errors.any? %>
 <div class="error-alert">
   <ul>
-    <% @item.errors.full_messages.each do |message| %>
+    <% model.errors.full_messages.each do |message| %>
     <li class='error-message'><%= message %></li>
     <% end %>
   </ul>


### PR DESCRIPTION
what 
１商品詳細ページへの遷移　
２詳細画面の情報表示
３ユーザーの状態によって処理を変更する
why
１パスを指定した
２コントローラーにshowアクションを定義した、それぞれの項目にコントローラーで定義したインスタンス変数を用いて表示
３ログインユーザーは詳細と購入、ログアウトユーザーは条件分岐で詳細だけ見れる様に分岐した
　編集と消去はか投稿本人しか表示されないような条件分岐を実行した。
ログアウトユーザーが商品詳細に遷移した際の表示https://gyazo.com/f881803a7436696c3cce572b73ec58d1
自身が出品した商品への遷移https://gyazo.com/d8504de7bb0b611ed8a95e6632ff49c3
他人が出品した商品への遷移https://gyazo.com/5336b3439b65f665c78fb0337a06ad2f
ソールドアウトに関してはコメントアウトにしています、ご確認お願い致します。